### PR TITLE
2021-07-08 GUARD-2014 GUARD-1846 NewEgg_InventorySync_FailedWith_CT055Error

### DIFF
--- a/src/NewEggAccess/BusinessAccount/Models/Commands/GetFeedStatusCommand.cs
+++ b/src/NewEggAccess/BusinessAccount/Models/Commands/GetFeedStatusCommand.cs
@@ -1,0 +1,15 @@
+﻿using CuttingEdge.Conditions;
+using NewEggAccess.Configuration;
+
+namespace NewEggAccess.BusinessAccount.Models.Commands
+{
+	public class GetFeedStatusCommand : NewEggCommand
+	{
+		public GetFeedStatusCommand( NewEggConfig config, NewEggCredentials credentials, string payload ) : base( config, credentials, GetFeedStatusServiceUrl )
+		{
+			Condition.Requires( payload, "payload" ).IsNotNullOrWhiteSpace();
+
+			this.Payload = payload;
+		}
+	}
+}

--- a/src/NewEggAccess/BusinessAccount/Models/Commands/GetItemInventoryCommand.cs
+++ b/src/NewEggAccess/BusinessAccount/Models/Commands/GetItemInventoryCommand.cs
@@ -1,0 +1,15 @@
+﻿using CuttingEdge.Conditions;
+using NewEggAccess.Configuration;
+
+namespace NewEggAccess.BusinessAccount.Models.Commands
+{
+	public class GetItemInventoryCommand : NewEggCommand
+	{
+		public GetItemInventoryCommand( NewEggConfig config, NewEggCredentials credentials, string payload ) : base( config, credentials, GetItemInventoryServiceUrl )
+		{
+			Condition.Requires( payload, "payload" ).IsNotNullOrWhiteSpace();
+
+			this.Payload = payload;
+		}
+	}
+}

--- a/src/NewEggAccess/BusinessAccount/Models/Commands/GetModifiedOrdersCommand.cs
+++ b/src/NewEggAccess/BusinessAccount/Models/Commands/GetModifiedOrdersCommand.cs
@@ -1,0 +1,16 @@
+﻿using CuttingEdge.Conditions;
+using NewEggAccess.Configuration;
+
+namespace NewEggAccess.BusinessAccount.Models.Commands
+{
+	public class GetModifiedOrdersCommand : NewEggCommand
+	{
+		public GetModifiedOrdersCommand( NewEggConfig config, NewEggCredentials credentials, string payload ) : base( config, credentials, GetModifiedOrdersServiceUrl )
+		{
+			Condition.Requires( payload, "payload" ).IsNotNullOrWhiteSpace();
+
+			this.Payload = payload;
+			this.AddUrlParameter( "version", ApiVersion );
+		}
+	}
+}

--- a/src/NewEggAccess/BusinessAccount/Models/Commands/NewEggCommand.cs
+++ b/src/NewEggAccess/BusinessAccount/Models/Commands/NewEggCommand.cs
@@ -1,0 +1,56 @@
+﻿using CuttingEdge.Conditions;
+using NewEggAccess.Configuration;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace NewEggAccess.BusinessAccount.Models.Commands
+{
+	public abstract class NewEggCommand
+	{
+		public const string GetItemInventoryServiceUrl = "/contentmgmt/item/inventory";
+		public const string UpdateItemInventoryServiceUrl = "/contentmgmt/item/inventoryandprice";
+		public const string SubmitFeedServiceUrl = "/datafeedmgmt/feeds/submitfeed";
+		public const string GetFeedStatusServiceUrl = "/datafeedmgmt/feeds/status";
+		public const string GetModifiedOrdersServiceUrl = "/ordermgmt/order/orderinfo";
+
+		public const string ApiVersion = "305";
+
+		public NewEggConfig Config { get; private set; }
+		public NewEggCredentials Credentials { get; private set; }
+		public string RelativeUrl { get; private set; }
+
+		public string Url
+		{
+			get 
+			{
+				var urlParameters = string.Join( "&", this._urlParameters.Select( pair => $"{ pair.Key }={ pair.Value }" ) );
+				return $"{ this.Config.ApiBaseUrl }{ "/b2b" }{ this.RelativeUrl }?{ urlParameters }"; 
+			}
+		}
+		public string Payload { get; protected set; }
+
+		private Dictionary< string, string > _urlParameters { get; set; }
+
+		protected NewEggCommand( NewEggConfig config, NewEggCredentials credentials, string relativeUrl )
+		{
+			Condition.Requires( config, "config" ).IsNotNull();
+			Condition.Requires( credentials, "credentials" ).IsNotNull();
+
+			this.Config = config;
+			this.Credentials = credentials;
+			this.RelativeUrl = relativeUrl;
+			this._urlParameters = new Dictionary< string, string >
+			{
+				{ "sellerId", this.Credentials.SellerId }
+			};
+		}
+		
+		protected void AddUrlParameter( string name, string value )
+		{
+			Condition.Requires( name, "name" ).IsNotNullOrWhiteSpace();
+			Condition.Requires( value, "value" ).IsNotNullOrWhiteSpace();
+
+			this._urlParameters.Add( name, value );
+		}
+	}
+}

--- a/src/NewEggAccess/BusinessAccount/Models/Commands/SubmitFeedCommand.cs
+++ b/src/NewEggAccess/BusinessAccount/Models/Commands/SubmitFeedCommand.cs
@@ -1,0 +1,21 @@
+﻿using CuttingEdge.Conditions;
+using NewEggAccess.Configuration;
+
+namespace NewEggAccess.BusinessAccount.Models.Commands
+{
+	public class SubmitFeedCommand : NewEggCommand
+	{
+		public SubmitFeedCommand( NewEggConfig config, NewEggCredentials credentials, SubmitFeedRequestTypeEnum requestType, string payload ) : base( config, credentials, SubmitFeedServiceUrl )
+		{
+			Condition.Requires( payload, "payload" ).IsNotNullOrWhiteSpace();
+
+			this.Payload = payload;
+			base.AddUrlParameter( "requesttype", requestType.ToString().ToUpper() );
+		}
+	}
+
+	public enum SubmitFeedRequestTypeEnum
+	{
+		Inventory_And_Price_Data
+	}
+}

--- a/src/NewEggAccess/BusinessAccount/Models/Commands/UpdateItemInventoryCommand.cs
+++ b/src/NewEggAccess/BusinessAccount/Models/Commands/UpdateItemInventoryCommand.cs
@@ -1,0 +1,15 @@
+﻿using CuttingEdge.Conditions;
+using NewEggAccess.Configuration;
+
+namespace NewEggAccess.BusinessAccount.Models.Commands
+{
+	public class UpdateItemInventoryCommand : NewEggCommand
+	{
+		public UpdateItemInventoryCommand( NewEggConfig config, NewEggCredentials credentials, string payload ) : base( config, credentials, UpdateItemInventoryServiceUrl )
+		{
+			Condition.Requires( payload, "payload" ).IsNotNullOrWhiteSpace();
+
+			this.Payload = payload;
+		}
+	}
+}

--- a/src/NewEggAccess/BusinessAccount/Models/Feeds/UpdateInventoryFeedRequest.cs
+++ b/src/NewEggAccess/BusinessAccount/Models/Feeds/UpdateInventoryFeedRequest.cs
@@ -1,0 +1,38 @@
+﻿using CuttingEdge.Conditions;
+using NewEggAccess.Models.Items;
+using System.Collections.Generic;
+
+namespace NewEggAccess.BusinessAccount.Models.Feeds
+{
+	public class UpdateInventoryFeedRequestBody
+	{
+		public InventoryUpdateFeed Inventory { get; set; }
+	}
+
+	public class InventoryUpdateFeed
+	{
+		public IEnumerable< InventoryUpdateFeedItem > Item { get; private set; }
+
+		public InventoryUpdateFeed( IEnumerable< InventoryUpdateFeedItem > items )
+		{
+			Condition.Requires( items, "items " ).IsNotEmpty();
+
+			this.Item = items;
+		}
+	}
+
+	public class InventoryUpdateFeedItem
+	{
+		public string SellerPartNumber { get; private set; }		
+		public int Inventory { get; private set; }
+
+		public InventoryUpdateFeedItem( string sellerPartNumber, int inventory )
+		{
+			Condition.Requires( sellerPartNumber, "sku/sellerPartNumber" ).IsNotNullOrWhiteSpace().IsNotLongerThan( ItemInventoryRequest.MaxSellerPartNumberLength );			
+			Condition.Requires( inventory, "inventory" ).IsGreaterOrEqual( 0 );
+
+			this.SellerPartNumber = sellerPartNumber;			
+			this.Inventory = inventory;
+		}
+	}
+}

--- a/src/NewEggAccess/BusinessAccount/Models/Items/GetItemInventoryRequest.cs
+++ b/src/NewEggAccess/BusinessAccount/Models/Items/GetItemInventoryRequest.cs
@@ -1,0 +1,18 @@
+﻿using CuttingEdge.Conditions;
+
+namespace NewEggAccess.BusinessAccount.Models.Items
+{
+	public class GetItemInventoryRequest
+	{
+		public int Type { get; private set; }
+		public string Value { get; private set; }		
+
+		public GetItemInventoryRequest( int type, string value )
+		{
+			Condition.Requires( value, $"sku {value}" ).IsNotNullOrWhiteSpace().IsNotLongerThan( ItemInventoryRequest.MaxSellerPartNumberLength );			
+
+			this.Value = value;
+			this.Type = type;			
+		}
+	}
+}

--- a/src/NewEggAccess/BusinessAccount/Models/Items/ItemInventory.cs
+++ b/src/NewEggAccess/BusinessAccount/Models/Items/ItemInventory.cs
@@ -1,0 +1,11 @@
+﻿namespace NewEggAccess.BusinessAccount.Models.Items
+{
+	public class ItemInventory
+	{
+		public string SellerId { get; set; }
+		public string ItemNumber { get; set; }
+		public string SellerPartNumber { get; set; }
+		public int FulFillmentOption { get; set; }
+		public int AvailableQuantity { get; set; }
+	}
+}

--- a/src/NewEggAccess/BusinessAccount/Models/Items/ItemInventoryRequest.cs
+++ b/src/NewEggAccess/BusinessAccount/Models/Items/ItemInventoryRequest.cs
@@ -1,0 +1,7 @@
+﻿namespace NewEggAccess.BusinessAccount.Models.Items
+{
+	public static class ItemInventoryRequest
+	{
+		public const int MaxSellerPartNumberLength = 40;
+	}
+}

--- a/src/NewEggAccess/BusinessAccount/Models/Items/UpdateItemInventoryRequest.cs
+++ b/src/NewEggAccess/BusinessAccount/Models/Items/UpdateItemInventoryRequest.cs
@@ -1,0 +1,28 @@
+﻿using CuttingEdge.Conditions;
+
+namespace NewEggAccess.BusinessAccount.Models.Items
+{
+	public class UpdateItemInventoryRequest
+	{
+		public int Type { get; private set; }
+		public string Value { get; private set; }
+		public int Inventory { get; private set; }
+
+		public UpdateItemInventoryRequest( int type, string value, int quantity )
+		{
+			Condition.Requires( value, $"sku {value}" ).IsNotNullOrWhiteSpace().IsNotLongerThan( ItemInventoryRequest.MaxSellerPartNumberLength );
+			
+			this.Value = value;
+			this.Type = type;
+			this.Inventory = quantity;
+		}
+	}
+
+	public class BusinessAccountUpdateItemInventoryResponse
+	{
+		public string SellerId { get; set; }
+		public string ItemNumber { get; set; }
+		public string SellerPartNumber { get; set; }
+		public int AvailableQuantity { get; set; }
+	}
+}

--- a/src/NewEggAccess/BusinessAccount/Services/BaseService.cs
+++ b/src/NewEggAccess/BusinessAccount/Services/BaseService.cs
@@ -1,0 +1,275 @@
+﻿using CuttingEdge.Conditions;
+using NewEggAccess.BusinessAccount.Models.Commands;
+using NewEggAccess.Configuration;
+using NewEggAccess.Exceptions;
+using NewEggAccess.Models;
+using NewEggAccess.Services;
+using NewEggAccess.Shared;
+using NewEggAccess.Throttling;
+using Newtonsoft.Json;
+using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NewEggAccess.BusinessAccount.Services
+{
+	public class BaseService
+	{
+		protected NewEggCredentials Credentials { get; private set; }
+		protected NewEggConfig Config { get; private set; }
+		private Throttler _throttler;
+		public IHttpClient HttpClient;
+
+		private Func< string > _additionalLogInfo;
+		private const int _tooManyRequestsHttpCode = 429;
+
+		/// <summary>
+		///	Extra logging information
+		/// </summary>
+		public Func< string > AdditionalLogInfo
+		{
+			get { return this._additionalLogInfo ?? ( () => string.Empty ); }
+			set => _additionalLogInfo = value;
+		}
+
+		public Throttler Throttler
+		{
+			get
+			{
+				return _throttler;
+			}
+		}
+
+		public BaseService( NewEggCredentials credentials, NewEggConfig config )
+		{
+			Condition.Requires( credentials, "credentials" ).IsNotNull();
+			Condition.Requires( config, "config" ).IsNotNull();
+
+			this.Credentials = credentials;
+			this.Config = config;
+
+			this._throttler = new Throttler( config.ThrottlingOptions.MaxRequestsPerTimeInterval, config.ThrottlingOptions.TimeIntervalInSec );
+			this.HttpClient = new DefaultHttpClient();
+			this.HttpClient.SetAcceptHeader( new MediaTypeWithQualityHeaderValue( "application/json" ) );
+
+			SetAuthorizationHeaders();
+		}
+
+		private void SetAuthorizationHeaders()
+		{
+			this.HttpClient.SetRequestHeader( "Authorization", this.Credentials.ApiKey );
+			this.HttpClient.SetRequestHeader( "SecretKey", this.Credentials.SecretKey );
+		}
+
+		protected Task< ServerResponse > GetAsync( string url, CancellationToken cancellationToken, Mark mark, Func< HttpStatusCode, ErrorResponse, bool > ignoreError )
+		{
+			if ( cancellationToken.IsCancellationRequested )
+			{
+				var exceptionDetails = CreateMethodCallInfo( url, mark, additionalInfo: this.AdditionalLogInfo() );
+				throw new NewEggException( string.Format( "{0}. Task was cancelled", exceptionDetails ) );
+			}
+
+			return this.ThrottleRequest( url, string.Empty, mark, async ( token ) =>
+			{
+				var httpResponse = await HttpClient.GetAsync( url ).ConfigureAwait( false );
+				var content = await httpResponse.ReadContentAsStringAsync().ConfigureAwait( false );
+
+				this.SaveAndLogRateLimits( httpResponse, CreateMethodCallInfo( url, mark, additionalInfo: this.AdditionalLogInfo() ) );
+				var errorResponse = ThrowIfError( httpResponse, content, ignoreError );
+
+				return new ServerResponse() { Result = content, Error = errorResponse };
+			}, cancellationToken );
+		}
+		
+		protected Task< ServerResponse > PutAsync( NewEggCommand command, CancellationToken cancellationToken, Mark mark, Func< HttpStatusCode, ErrorResponse, bool > ignoreError )
+		{
+			if ( cancellationToken.IsCancellationRequested )
+			{
+				var exceptionDetails = CreateMethodCallInfo( command.Url, mark, additionalInfo: this.AdditionalLogInfo() );
+				throw new NewEggException( string.Format( "{0}. Task was cancelled", exceptionDetails ) );
+			}
+
+			return this.ThrottleRequest( command.Url, command.Payload, mark, async ( token ) =>
+			{
+				var payload = new StringContent( command.Payload, Encoding.UTF8, "application/json" );				
+				// NewEgg service responds only on application/json without charset specified
+				payload.Headers.ContentType = MediaTypeHeaderValue.Parse( "application/json" );
+				var httpResponse = await HttpClient.PutAsync( command.Url, payload, token ).ConfigureAwait( false );
+				var content = await httpResponse.ReadContentAsStringAsync().ConfigureAwait( false );
+
+				this.SaveAndLogRateLimits( httpResponse, CreateMethodCallInfo( command.Url, mark, additionalInfo: this.AdditionalLogInfo() ) );
+				var errorResponse = ThrowIfError( httpResponse, content, ignoreError );
+
+				return new ServerResponse() { Result = content, Error = errorResponse };
+				
+			}, cancellationToken );
+		}
+
+		protected Task< ServerResponse > PostAsync( NewEggCommand command, CancellationToken cancellationToken, Mark mark, Func< HttpStatusCode, ErrorResponse, bool > ignoreError )
+		{
+			if ( cancellationToken.IsCancellationRequested )
+			{
+				var exceptionDetails = CreateMethodCallInfo( command.Url, mark, additionalInfo: this.AdditionalLogInfo() );
+				throw new NewEggException( string.Format( "{0}. Task was cancelled", exceptionDetails ) );
+			}
+
+			return this.ThrottleRequest( command.Url, command.Payload, mark, async ( token ) =>
+			{
+				var payload = new StringContent( command.Payload, Encoding.UTF8, "application/json" );
+				// NewEgg service responds only on application/json without charset specified
+				payload.Headers.ContentType = MediaTypeHeaderValue.Parse( "application/json" );
+				var httpResponse = await HttpClient.PostAsync( command.Url, payload, token ).ConfigureAwait( false );
+				var content = await httpResponse.ReadContentAsStringAsync().ConfigureAwait( false );
+
+				this.SaveAndLogRateLimits( httpResponse, CreateMethodCallInfo( command.Url, mark, additionalInfo: this.AdditionalLogInfo() ) );
+				var errorResponse = ThrowIfError( httpResponse, content, ignoreError );
+
+				return new ServerResponse() { Result = content, Error = errorResponse };
+			}, cancellationToken );
+		}
+
+		protected ErrorResponse ThrowIfError( IHttpResponseMessage response, string message, Func< HttpStatusCode, ErrorResponse, bool > ignoreError )
+		{
+			ErrorResponse errorResponse = null;
+			HttpStatusCode responseStatusCode = response.StatusCode;
+
+			if ( response.IsSuccessStatusCode )
+				return errorResponse;
+
+			try
+			{
+				if ( message != null )
+				{
+					var errors = JsonConvert.DeserializeObject< ErrorResponse[] >( message );
+					errorResponse = errors.FirstOrDefault();
+				}
+			}
+			catch { }
+
+			// ignore errors which is not errors actually like item was not found
+			if ( ignoreError( response.StatusCode, errorResponse ) )
+			{
+				return errorResponse;
+			}
+
+			if ( responseStatusCode == HttpStatusCode.Unauthorized )
+			{
+				throw new NewEggUnauthorizedException( message );
+			}
+			else if ( responseStatusCode == HttpStatusCode.InternalServerError
+					|| responseStatusCode == HttpStatusCode.BadRequest )
+			{
+				throw new NewEggException( message );
+			}
+			else if ( (int)responseStatusCode == _tooManyRequestsHttpCode )
+			{
+				throw new NewEggRateLimitsExceeded( message );
+			}
+
+			throw new NewEggException( message );
+		}
+
+		private void SaveAndLogRateLimits( IHttpResponseMessage response, string info )
+		{
+			var limits = GetRateLimit( response );
+
+			if ( limits != null )
+			{
+				this._throttler.RateLimit.Limit = limits.Limit;
+				this._throttler.RateLimit.Remaining = limits.Remaining;
+				this._throttler.RateLimit.ResetTime = limits.ResetTime;
+
+				NewEggLogger.LogTrace( String.Format( "{0}, Total calls: {1}, Remaining calls: {2}, Reset time: {3}", info, limits.Limit, limits.Remaining, limits.ResetTime ) );
+			}
+		}
+
+		private NewEggRateLimit GetRateLimit( IHttpResponseMessage response )
+		{
+			var rateLimit = response.GetHeaderValue( "X-RateLimit-Limit" );
+			var rateRemaining = response.GetHeaderValue( "X-RateLimit-Remaining" );
+			var rateResetTime = response.GetHeaderValue( "X-ratelimit-resettime" );
+
+			if ( !string.IsNullOrWhiteSpace( rateLimit )
+				&& !string.IsNullOrWhiteSpace( rateRemaining )
+				&& !string.IsNullOrWhiteSpace( rateResetTime ) )
+			{
+				return new NewEggRateLimit( rateLimit, rateRemaining, rateResetTime );
+			}
+
+			return null;
+		}
+
+		protected Task< T > ThrottleRequest< T >( string url, string payload, Mark mark, Func< CancellationToken, Task< T > > processor, CancellationToken token )
+		{
+			return Throttler.ExecuteAsync( () =>
+			{
+				return new ActionPolicy( Config.NetworkOptions.RetryAttempts, Config.NetworkOptions.DelayBetweenFailedRequestsInSec, Config.NetworkOptions.DelayFailRequestRate )
+					.ExecuteAsync( async () =>
+					{
+						using( var linkedTokenSource = CancellationTokenSource.CreateLinkedTokenSource( token ) )
+						{
+							NewEggLogger.LogStarted( this.CreateMethodCallInfo( url, mark, payload: payload, additionalInfo: this.AdditionalLogInfo() ) );
+							linkedTokenSource.CancelAfter( Config.NetworkOptions.RequestTimeoutMs );
+
+							var result = await processor( linkedTokenSource.Token ).ConfigureAwait( false );
+
+							NewEggLogger.LogEnd( this.CreateMethodCallInfo( url, mark, methodResult: result.ToJson(), additionalInfo: this.AdditionalLogInfo() ) );
+
+							return result;
+						}
+					}, 
+					( exception, timeSpan, retryCount ) =>
+					{
+						string retryDetails = CreateMethodCallInfo( url, mark, additionalInfo: this.AdditionalLogInfo() );
+						NewEggLogger.LogTraceRetryStarted( timeSpan.Seconds, retryCount, retryDetails );
+					},
+					() => CreateMethodCallInfo( url, mark, additionalInfo: this.AdditionalLogInfo() ),
+					NewEggLogger.LogTraceException );
+			} );
+		}
+
+		/// <summary>
+		///	Creates method calling detailed information
+		/// </summary>
+		/// <param name="url">Absolute path to service endpoint</param>
+		/// <param name="mark">Unique stamp to track concrete method</param>
+		/// <param name="errors">Errors</param>
+		/// <param name="methodResult">Service endpoint raw result</param>
+		/// <param name="payload">Method payload (POST)</param>
+		/// <param name="additionalInfo">Extra logging information</param>
+		/// <param name="memberName">Method name</param>
+		/// <returns></returns>
+		protected string CreateMethodCallInfo( string url = "", Mark mark = null, string errors = "", string methodResult = "", string additionalInfo = "", string payload = "", [ CallerMemberName ] string memberName = "" )
+		{
+			string serviceEndPoint = null;
+			string requestParameters = null;
+
+			if ( !string.IsNullOrEmpty( url ) )
+			{
+				Uri uri = new Uri( url.Contains( Config.ApiBaseUrl ) ? url : Config.ApiBaseUrl + url );
+
+				serviceEndPoint = uri.LocalPath;
+				requestParameters = uri.Query;
+			}
+
+			var str = string.Format(
+				"{{MethodName: {0}, Mark: '{1}', ServiceEndPoint: '{2}', {3} {4}{5}{6}{7}}}",
+				memberName,
+				mark ?? Mark.Blank(),
+				string.IsNullOrWhiteSpace( serviceEndPoint ) ? string.Empty : serviceEndPoint,
+				string.IsNullOrWhiteSpace( requestParameters ) ? string.Empty : ", RequestParameters: " + requestParameters,
+				string.IsNullOrWhiteSpace( errors ) ? string.Empty : ", Errors:" + errors,
+				string.IsNullOrWhiteSpace( methodResult ) ? string.Empty : ", Result:" + methodResult,
+				string.IsNullOrWhiteSpace( payload ) ? string.Empty : ", Payload:" + payload,
+				string.IsNullOrWhiteSpace( additionalInfo ) ? string.Empty : ", " + additionalInfo
+			);
+			return str;
+		}
+	}
+}

--- a/src/NewEggAccess/BusinessAccount/Services/Creds/NewEggCredsService.cs
+++ b/src/NewEggAccess/BusinessAccount/Services/Creds/NewEggCredsService.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using NewEggAccess.BusinessAccount.Models.Commands;
+using NewEggAccess.Configuration;
+using NewEggAccess.Exceptions;
+using NewEggAccess.Models.Orders;
+using NewEggAccess.Services.Creds;
+using NewEggAccess.Shared;
+
+namespace NewEggAccess.BusinessAccount.Services.Creds
+{
+	public class NewEggCredsService : BaseService, INewEggCredsService
+	{
+		public NewEggCredsService( NewEggConfig config, NewEggCredentials credentials ) : base( credentials, config )
+		{
+		}
+
+		public async Task<bool> AreNewEggCredentialsValid( CancellationToken token, Mark mark = null )
+		{
+			if ( mark == null )
+			{
+				mark = Mark.CreateNew();
+			}
+
+			int pageIndex = 1;
+			DateTime startDateUtc = DateTime.UtcNow;
+			DateTime endDateUtc = startDateUtc.AddMinutes( 1 );
+
+			var request = new GetOrderInfoRequest(
+					new GetOrderInfoRequestBody(
+						pageIndex,
+						base.Config.OrdersPageSize,
+						new GetOrderInfoRequestCriteria()
+						{
+							Type = 0,
+							Status = ( int )NewEggOrderStatusEnum.Unshipped,
+							OrderDateFrom = Misc.ConvertFromUtcToPstStr( startDateUtc ),
+							OrderDateTo = Misc.ConvertFromUtcToPstStr( endDateUtc )							
+						} ) );
+
+			var ordersPageServerResponse = await base.PutAsync( new GetModifiedOrdersCommand( base.Config, base.Credentials, request.ToJson() ), token, mark, ( code, response ) => false ).ConfigureAwait( false );
+
+			if ( ordersPageServerResponse.Error == null )
+			{
+				return true;
+			}
+			else
+			{
+				throw new NewEggException( ordersPageServerResponse.Error.Message );
+			}
+		}		
+	}
+}

--- a/src/NewEggAccess/BusinessAccount/Services/Feeds/NewEggFeedsService.cs
+++ b/src/NewEggAccess/BusinessAccount/Services/Feeds/NewEggFeedsService.cs
@@ -1,0 +1,124 @@
+﻿using CuttingEdge.Conditions;
+using NewEggAccess.BusinessAccount.Models.Commands;
+using NewEggAccess.Configuration;
+using NewEggAccess.Exceptions;
+using NewEggAccess.Models.Feeds;
+using NewEggAccess.Services.Feeds;
+using NewEggAccess.Shared;
+using Newtonsoft.Json;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using UpdateInventoryFeedRequestBody = NewEggAccess.BusinessAccount.Models.Feeds.UpdateInventoryFeedRequestBody;
+using InventoryUpdateFeed = NewEggAccess.BusinessAccount.Models.Feeds.InventoryUpdateFeed;
+using InventoryUpdateFeedItemBusinessAccount = NewEggAccess.BusinessAccount.Models.Feeds.InventoryUpdateFeedItem;
+
+namespace NewEggAccess.BusinessAccount.Services.Feeds
+{
+	public class NewEggFeedsService : BaseService, INewEggFeedsService
+	{
+		public NewEggFeedsService( NewEggConfig config, NewEggCredentials credentials ) : base( credentials, config )
+		{
+		}
+
+		/// <summary>
+		///	Submit feed with inventory data (batch update items inventory)
+		/// </summary>
+		/// <param name="inventory"></param>
+		/// <param name="token"></param>
+		/// <param name="mark"></param>
+		/// <returns>Feed id</returns>
+		public async Task< string > UpdateItemsInventoryInBulkAsync( IEnumerable< InventoryUpdateFeedItem > inventory, CancellationToken token, Mark mark = null )
+		{
+			Condition.Requires( inventory, "inventory" ).IsNotEmpty();
+
+			if ( mark == null )
+			{
+				mark = Mark.CreateNew();
+			}
+
+			var request = PrepareUpdateInventoryFeedRequest(inventory);
+
+			var command = new SubmitFeedCommand( base.Config, base.Credentials, SubmitFeedRequestTypeEnum.Inventory_And_Price_Data, request.ToJson() );
+
+			var serverResponse = await base.PostAsync( command, token, mark, ( code, error ) => false ).ConfigureAwait( false );
+
+			if ( serverResponse.Error == null )
+			{
+				var response = JsonConvert.DeserializeObject< NewEggApiResponse< UpdateInventoryFeedResponse > >( serverResponse.Result );
+
+				if ( !response.IsSuccess )
+				{
+					throw new NewEggException( response.ToJson() );
+				}
+
+				return response.ResponseBody.ResponseList.First().RequestId;
+			}
+
+			return null;
+		}
+
+		/// <summary>
+		///	Get feed status
+		/// </summary>
+		/// <param name="feedId">Feed id</param>
+		/// <param name="token">Cancellation token</param>
+		/// <param name="mark"></param>
+		/// <returns></returns>
+		public async Task< FeedAcknowledgment > GetFeedStatusAsync( string feedId, CancellationToken token, Mark mark = null )
+		{
+			Condition.Requires( feedId, "feedId" ).IsNotNullOrWhiteSpace();
+
+			if ( mark == null )
+			{
+				mark = Mark.CreateNew();
+			}
+
+			var request = new NewEggApiRequest< GetRequestStatusWrapper >{  
+				OperationType = "GetFeedStatusRequest", 
+				RequestBody = new GetRequestStatusWrapper{ 
+					GetRequestStatus = new GetRequestStatus
+					{
+						RequestIDList = new RequestIdList{ RequestID = feedId }, 
+						MaxCount = 100, 
+						RequestStatus = "ALL" 
+					}
+				} 
+			};
+
+			var command = new GetFeedStatusCommand( base.Config, base.Credentials, request.ToJson() );
+
+			var serverResponse = await base.PutAsync( command, token, mark, ( code, error ) => false ).ConfigureAwait( false );
+
+			if ( serverResponse.Error == null )
+			{
+				var response = JsonConvert.DeserializeObject< NewEggApiResponse< FeedAcknowledgment > >( serverResponse.Result );
+
+				if ( !response.IsSuccess )
+				{
+					throw new NewEggException( response.ToJson() );
+				}
+
+				return response.ResponseBody.ResponseList.FirstOrDefault();
+			}
+
+			return null;
+		}
+
+		private NewEggEnvelopeWrapper< UpdateInventoryFeedRequestBody > PrepareUpdateInventoryFeedRequest( IEnumerable< InventoryUpdateFeedItem > inventory )
+		{			
+			var inventoryItems = new List< InventoryUpdateFeedItemBusinessAccount >();
+
+			foreach ( var inventoryItem in inventory )
+			{
+				inventoryItems.Add( new InventoryUpdateFeedItemBusinessAccount( inventoryItem.SellerPartNumber, inventoryItem.Inventory ) );				
+			}
+
+			return new NewEggEnvelopeWrapper< UpdateInventoryFeedRequestBody >
+			{
+				NeweggEnvelope = new NewEggEnvelope< UpdateInventoryFeedRequestBody >("Inventory", new UpdateInventoryFeedRequestBody() { Inventory = new InventoryUpdateFeed( inventoryItems ) })
+			};
+		}
+	}
+}

--- a/src/NewEggAccess/BusinessAccount/Services/Items/NewEggItemsService.cs
+++ b/src/NewEggAccess/BusinessAccount/Services/Items/NewEggItemsService.cs
@@ -1,0 +1,193 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using NewEggAccess.BusinessAccount.Models.Commands;
+using NewEggAccess.Configuration;
+using NewEggAccess.Models;
+using NewEggAccess.Shared;
+using Newtonsoft.Json;
+using BusinessAccountItemInventory = NewEggAccess.BusinessAccount.Models.Items.ItemInventory;
+using GetItemInventoryRequest = NewEggAccess.BusinessAccount.Models.Items.GetItemInventoryRequest;
+using ItemInventory = NewEggAccess.Models.Items.ItemInventory;
+using ItemInventoryAllocation = NewEggAccess.Models.Items.ItemInventoryAllocation;
+using UpdateItemInventoryResponse = NewEggAccess.Models.Items.UpdateItemInventoryResponse;
+using UpdateItemInventory = NewEggAccess.Models.Items.UpdateItemInventory;
+using UpdateItemInventoryRequest = NewEggAccess.BusinessAccount.Models.Items.UpdateItemInventoryRequest;
+using BusinessAccountUpdateItemInventoryResponse = NewEggAccess.BusinessAccount.Models.Items.BusinessAccountUpdateItemInventoryResponse;
+
+using NewEggAccess.Services.Items;
+
+namespace NewEggAccess.BusinessAccount.Services.Items
+{
+	public class NewEggItemsService : BaseService, INewEggItemsService
+	{
+		const int SellerPartNumberRequestType = 1;
+
+		public NewEggItemsService( NewEggConfig config, NewEggCredentials credentials ) : base( credentials, config )
+		{
+		}
+
+		/// <summary>
+		///	Get sku's inventory on specified warehouseLocation
+		/// </summary>
+		/// <param name="sku"></param>
+		/// <param name="warehouseLocationCode"></param>
+		/// <param name="token"></param>
+		/// <returns></returns>
+		public async Task< ItemInventory > GetSkuInventory( string sku, string warehouseLocationCode, CancellationToken token, Mark mark = null )
+		{
+			if ( mark == null )
+			{
+				mark = Mark.CreateNew();
+			}
+
+			var request = new GetItemInventoryRequest( type: SellerPartNumberRequestType, value: sku );
+
+			Func< HttpStatusCode, ErrorResponse, bool > ignoreErrorHandler = ( status, error ) =>
+			{
+				// can't find item
+				return error != null 
+						&& error.Code == "CT026"
+						&& status == HttpStatusCode.BadRequest;
+			};
+
+			var response = await base.PostAsync( new GetItemInventoryCommand( base.Config, base.Credentials, request.ToJson() ), token, mark, ignoreErrorHandler );
+			
+			if ( response.Error == null && response.Result != null )
+			{
+				return JsonConvert.DeserializeObject< ItemInventory >( response.Result, new NewEggGetItemInventoryResponseJsonConverter() );
+			}
+			
+			return null;
+		}
+
+		/// <summary>
+		///	Update sku's quantity
+		/// </summary>
+		/// <param name="sku"></param>
+		/// <param name="warehouseLocation"></param>
+		/// <param name="quantity"></param>
+		/// <param name="token"></param>
+		/// <returns></returns>
+		public async Task< UpdateItemInventoryResponse > UpdateSkuQuantityAsync( string sku, string warehouseLocationCountryCode, int quantity, CancellationToken token, Mark mark = null )
+		{
+			if ( mark == null )
+			{
+				mark = Mark.CreateNew();
+			}
+
+			var request = new UpdateItemInventoryRequest( SellerPartNumberRequestType, value: sku, quantity );
+
+			Func< HttpStatusCode, ErrorResponse, bool > ignoreErrorHandler = ( status, error ) =>
+			{
+				  // can't find item
+				  return error != null
+						&& error.Code == "CT015"
+						&& status == HttpStatusCode.BadRequest;
+			};
+
+			var response = await base.PutAsync( new UpdateItemInventoryCommand( base.Config, base.Credentials, request.ToJson() ), token, mark, ignoreErrorHandler );
+
+			if ( response.Error == null )
+			{
+				return JsonConvert.DeserializeObject< UpdateItemInventoryResponse >( response.Result, new NewEggGetUpdateInventoryResponseJsonConverter() );
+			}
+
+			return null;
+		}
+
+		/// <summary>
+		///	Updates skus quantities
+		/// </summary>
+		/// <param name="skusQuantities"></param>
+		/// <param name="token"></param>
+		/// <param name="mark"></param>
+		/// <returns></returns>
+		public async Task UpdateSkusQuantitiesAsync( Dictionary<string, int> skusQuantities, string warehouseLocationCode, CancellationToken token, Mark mark = null )
+		{
+			foreach ( var skuQuantity in skusQuantities )
+			{
+				await this.UpdateSkuQuantityAsync( skuQuantity.Key, string.Empty, skuQuantity.Value, token, mark ).ConfigureAwait( false );
+			}
+		}
+	}
+
+	public class NewEggGetItemInventoryResponseJsonConverter : JsonConverter
+	{		
+		public override void WriteJson( JsonWriter writer, object value, JsonSerializer serializer )
+		{
+			throw new NotImplementedException();
+		}
+
+		public override object ReadJson( JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer )
+		{
+			var source = serializer.Deserialize< BusinessAccountItemInventory >( reader );
+
+			return new ItemInventory
+			{
+				ItemNumber = source.ItemNumber,
+				SellerId = source.SellerId,
+				SellerPartNumber = source.SellerPartNumber,
+				InventoryAllocation = new ItemInventoryAllocation[]
+				{
+					new ItemInventoryAllocation
+					{
+						AvailableQuantity = source.AvailableQuantity,
+						FulFillmentOption = source.FulFillmentOption,
+						WarehouseLocationCode = "USA"
+					}
+				}
+			};
+		}
+
+		public override bool CanRead
+		{
+			get { return true; }
+		}
+
+		public override bool CanConvert( Type type )
+		{
+			return typeof( ItemInventory ).IsAssignableFrom( type );
+		}
+	}
+
+	public class NewEggGetUpdateInventoryResponseJsonConverter : JsonConverter
+	{		
+		public override void WriteJson( JsonWriter writer, object value, JsonSerializer serializer )
+		{
+			throw new NotImplementedException();
+		}
+
+		public override object ReadJson( JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer )
+		{
+			var source = serializer.Deserialize< BusinessAccountUpdateItemInventoryResponse >( reader );
+
+			return new UpdateItemInventoryResponse
+			{
+				ItemNumber = source.ItemNumber,
+				SellerId = source.SellerId,
+				SellerPartNumber = source.SellerPartNumber,
+				InventoryList = new UpdateItemInventory[]
+				{ 
+					new UpdateItemInventory
+					{ 
+						WarehouseLocation = "USA",
+						AvailableQuantity = source.AvailableQuantity
+					}
+				}
+			};
+		}
+
+		public override bool CanRead
+		{
+			get { return true; }
+		}
+
+		public override bool CanConvert( Type type )
+		{
+			return typeof( UpdateItemInventoryResponse ).IsAssignableFrom( type );
+		}
+	}
+}

--- a/src/NewEggAccess/BusinessAccount/Services/Items/NewEggItemsService.cs
+++ b/src/NewEggAccess/BusinessAccount/Services/Items/NewEggItemsService.cs
@@ -84,7 +84,7 @@ namespace NewEggAccess.BusinessAccount.Services.Items
 			{
 				  // can't find item
 				  return error != null
-						&& error.Code == "CT015"
+						&& ( error.Code == "CT015" || error.Code == "CT055" )
 						&& status == HttpStatusCode.BadRequest;
 			};
 

--- a/src/NewEggAccess/BusinessAccount/Services/Orders/NewEggOrdersService.cs
+++ b/src/NewEggAccess/BusinessAccount/Services/Orders/NewEggOrdersService.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NewEggAccess.BusinessAccount.Models.Commands;
+using NewEggAccess.Configuration;
+using NewEggAccess.Exceptions;
+using NewEggAccess.Models.Orders;
+using NewEggAccess.Services.Orders;
+using NewEggAccess.Shared;
+using Newtonsoft.Json;
+
+namespace NewEggAccess.BusinessAccount.Services.Orders
+{
+	public class NewEggOrdersService : BaseService, INewEggOrdersService
+	{
+		public NewEggOrdersService( NewEggConfig config, NewEggCredentials credentials ) : base( credentials, config )
+		{
+		}
+
+		public async Task< IEnumerable< NewEggOrder > > GetModifiedOrdersAsync( DateTime startDateUtc, DateTime endDateUtc, string countryCode, CancellationToken token, Mark mark = null )
+		{
+			var orders = new List< NewEggOrder >();
+			// order status actually cannot be omitted in request body (API error)
+			orders.AddRange( await this.GetModifiedOrdersByStatusAsync( startDateUtc, endDateUtc, NewEggOrderStatusEnum.Unshipped, token, mark ).ConfigureAwait( false ) );
+			orders.AddRange( await this.GetModifiedOrdersByStatusAsync( startDateUtc, endDateUtc, NewEggOrderStatusEnum.PartiallyShipped, token, mark ).ConfigureAwait( false ) );
+			orders.AddRange( await this.GetModifiedOrdersByStatusAsync( startDateUtc, endDateUtc, NewEggOrderStatusEnum.Shipped, token, mark ).ConfigureAwait( false ) );
+			orders.AddRange( await this.GetModifiedOrdersByStatusAsync( startDateUtc, endDateUtc, NewEggOrderStatusEnum.Invoiced, token, mark ).ConfigureAwait( false ) );
+			orders.AddRange( await this.GetModifiedOrdersByStatusAsync( startDateUtc, endDateUtc, NewEggOrderStatusEnum.Voided, token, mark ).ConfigureAwait( false ) );
+
+			return orders;
+		}
+		
+		private async Task< IEnumerable< NewEggOrder > > GetModifiedOrdersByStatusAsync( DateTime startDateUtc, DateTime endDateUtc, NewEggOrderStatusEnum orderStatus, CancellationToken token, Mark mark = null )
+		{
+			var orders = new List< NewEggOrder >();
+
+			if ( mark == null )
+			{
+				mark = Mark.CreateNew();
+			}
+
+			int pageIndex = 1;
+
+			while ( true )
+			{
+				var request = new GetOrderInfoRequest(
+					new GetOrderInfoRequestBody(
+						pageIndex,
+						base.Config.OrdersPageSize,
+						new GetOrderInfoRequestCriteria()
+						{
+							Type = 0,
+							Status = (int)orderStatus,
+							OrderDateFrom = Misc.ConvertFromUtcToPstStr( startDateUtc ),
+							OrderDateTo = Misc.ConvertFromUtcToPstStr( endDateUtc )							
+						} ) );
+
+				var ordersPageServerResponse = await base.PutAsync( new GetModifiedOrdersCommand( base.Config, base.Credentials, request.ToJson() ), token, mark, ( code, response ) => false ).ConfigureAwait( false );
+
+				if ( ordersPageServerResponse.Error == null )
+				{
+					var ordersPage = JsonConvert.DeserializeObject< GetOrderInfoResponse >( ordersPageServerResponse.Result );
+
+					if ( ordersPage.IsSuccess )
+					{
+						if ( ordersPage.ResponseBody.OrderInfoList != null )
+						{
+							orders.AddRange( ordersPage.ResponseBody.OrderInfoList.Select( o => o.ToSVOrder() ) );
+							++pageIndex;
+						}
+
+						if ( ordersPage.ResponseBody.PageInfo.TotalPageCount <= pageIndex )
+						{
+							break;
+						}
+					}
+					else
+					{
+						break;
+					}
+				}
+				else
+				{
+					throw new NewEggException( ordersPageServerResponse.Error.Message );
+				}
+			}
+
+			return orders.ToArray();
+		}
+	}
+}

--- a/src/NewEggAccess/INewEggFactory.cs
+++ b/src/NewEggAccess/INewEggFactory.cs
@@ -1,4 +1,5 @@
 ﻿using NewEggAccess.Configuration;
+using NewEggAccess.Services.Creds;
 using NewEggAccess.Services.Feeds;
 using NewEggAccess.Services.Items;
 using NewEggAccess.Services.Orders;
@@ -10,5 +11,6 @@ namespace NewEggAccess
 		INewEggItemsService CreateItemsService( NewEggConfig config, string sellerId, string secretKey );
 		INewEggFeedsService CreateFeedsService( NewEggConfig config, string sellerId, string secretKey );
 		INewEggOrdersService CreateOrdersService( NewEggConfig config, string sellerId, string secretKey );
+		INewEggCredsService CreateCredsService( NewEggConfig config, string sellerId, string secretKey );
 	}
 }

--- a/src/NewEggAccess/Models/Feeds/UpdateInventoryFeedRequest.cs
+++ b/src/NewEggAccess/Models/Feeds/UpdateInventoryFeedRequest.cs
@@ -29,6 +29,9 @@ namespace NewEggAccess.Models.Feeds
 
 		public InventoryUpdateFeedItem( string sellerPartNumber, string warehouseLocation, int inventory )
 		{
+			if ( string.IsNullOrWhiteSpace( warehouseLocation ) )
+				warehouseLocation = "USA";
+
 			Condition.Requires( sellerPartNumber, "sku/sellerPartNumber" ).IsNotNullOrWhiteSpace().IsNotLongerThan( ItemInventoryRequest.MaxSellerPartNumberLength );
 			Condition.Requires( warehouseLocation, "warehouseLocation" ).IsNotNullOrWhiteSpace().HasLength( 3 );
 			Condition.Requires( inventory, "inventory" ).IsGreaterOrEqual( 0 );

--- a/src/NewEggAccess/NewEggAccess.csproj
+++ b/src/NewEggAccess/NewEggAccess.csproj
@@ -9,7 +9,7 @@
     <PackageLicenseUrl></PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/skuvault/newEggAccess</PackageProjectUrl>
     <RepositoryUrl>https://github.com/skuvault/newEggAccess</RepositoryUrl>
-    <Version>1.1.1.0-alpha</Version>
+    <Version>1.1.1.0</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <AssemblyVersion>1.1.1.0</AssemblyVersion>
     <FileVersion>1.1.1.0</FileVersion>

--- a/src/NewEggAccess/NewEggAccess.csproj
+++ b/src/NewEggAccess/NewEggAccess.csproj
@@ -9,10 +9,10 @@
     <PackageLicenseUrl></PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/skuvault/newEggAccess</PackageProjectUrl>
     <RepositoryUrl>https://github.com/skuvault/newEggAccess</RepositoryUrl>
-    <Version>1.0.5.0</Version>
+    <Version>1.1.0.0-alpha</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>1.0.5.0</AssemblyVersion>
-    <FileVersion>1.0.5.0</FileVersion>
+    <AssemblyVersion>1.1.0.0</AssemblyVersion>
+    <FileVersion>1.1.0.0</FileVersion>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>
 

--- a/src/NewEggAccess/NewEggAccess.csproj
+++ b/src/NewEggAccess/NewEggAccess.csproj
@@ -9,10 +9,10 @@
     <PackageLicenseUrl></PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/skuvault/newEggAccess</PackageProjectUrl>
     <RepositoryUrl>https://github.com/skuvault/newEggAccess</RepositoryUrl>
-    <Version>1.1.0.0-alpha</Version>
+    <Version>1.1.1.0-alpha</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <AssemblyVersion>1.1.0.0</AssemblyVersion>
-    <FileVersion>1.1.0.0</FileVersion>
+    <AssemblyVersion>1.1.1.0</AssemblyVersion>
+    <FileVersion>1.1.1.0</FileVersion>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>
 

--- a/src/NewEggAccess/NewEggFactory.cs
+++ b/src/NewEggAccess/NewEggFactory.cs
@@ -1,5 +1,6 @@
 ﻿using CuttingEdge.Conditions;
 using NewEggAccess.Configuration;
+using NewEggAccess.Services.Creds;
 using NewEggAccess.Services.Feeds;
 using NewEggAccess.Services.Items;
 using NewEggAccess.Services.Orders;
@@ -20,22 +21,41 @@ namespace NewEggAccess
 		public INewEggFeedsService CreateFeedsService( NewEggConfig config, string sellerId, string secretKey )
 		{
 			var credentials = new NewEggCredentials( sellerId, this._developerApiKey, secretKey );
+			
+			if ( config.Platform == NewEggPlatform.NewEgg )
+				return new NewEggFeedsService( config, credentials );
 
-			return new NewEggFeedsService( config, credentials );
+			return new BusinessAccount.Services.Feeds.NewEggFeedsService( config, credentials );
 		}
 
 		public INewEggItemsService CreateItemsService( NewEggConfig config, string sellerId, string secretKey )
 		{
 			var credentials = new NewEggCredentials( sellerId, this._developerApiKey, secretKey );
+			
+			if ( config.Platform == NewEggPlatform.NewEgg )
+				return new NewEggItemsService( config, credentials );
 
-			return new NewEggItemsService( config, credentials );
+			return new BusinessAccount.Services.Items.NewEggItemsService( config, credentials );
 		}
 
 		public INewEggOrdersService CreateOrdersService( NewEggConfig config, string sellerId, string secretKey )
 		{
 			var credentials = new NewEggCredentials( sellerId, this._developerApiKey, secretKey );
 
-			return new NewEggOrdersService( config, credentials );
+			if ( config.Platform == NewEggPlatform.NewEgg )
+				return new NewEggOrdersService( config, credentials );
+
+			return new BusinessAccount.Services.Orders.NewEggOrdersService( config, credentials );
+		}
+
+		public INewEggCredsService CreateCredsService( NewEggConfig config, string sellerId, string secretKey )
+		{
+			var credentials = new NewEggCredentials( sellerId, this._developerApiKey, secretKey );
+
+			if ( config.Platform == NewEggPlatform.NewEgg )
+				return new NewEggCredsService( config, credentials );
+
+			return new BusinessAccount.Services.Creds.NewEggCredsService( config, credentials );
 		}
 	}
 }

--- a/src/NewEggAccess/Services/BaseService.cs
+++ b/src/NewEggAccess/Services/BaseService.cs
@@ -98,7 +98,7 @@ namespace NewEggAccess.Services
 
 			return this.ThrottleRequest( command.Url, command.Payload, mark, async ( token ) =>
 			{
-				var payload = new StringContent( command.Payload, Encoding.UTF8, "application/json" );
+				var payload = new StringContent( command.Payload, Encoding.UTF8, "application/json" );				
 				// NewEgg service responds only on application/json without charset specified
 				payload.Headers.ContentType = MediaTypeHeaderValue.Parse( "application/json" );
 				var httpResponse = await HttpClient.PutAsync( command.Url, payload, token ).ConfigureAwait( false );
@@ -173,7 +173,7 @@ namespace NewEggAccess.Services
 				throw new NewEggRateLimitsExceeded( message );
 			}
 
-			throw new NewEggNetworkException( message );
+			throw new NewEggException( message );
 		}
 
 		private void SaveAndLogRateLimits( IHttpResponseMessage response, string info )

--- a/src/NewEggAccess/Services/Creds/INewEggCredsService.cs
+++ b/src/NewEggAccess/Services/Creds/INewEggCredsService.cs
@@ -1,0 +1,12 @@
+﻿using NewEggAccess.Shared;
+using NewEggAccess.Throttling;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NewEggAccess.Services.Creds
+{
+	public interface INewEggCredsService
+	{		
+		Task< bool > AreNewEggCredentialsValid( CancellationToken token, Mark mark = null );
+	}
+}

--- a/src/NewEggAccess/Services/Creds/NewEggCredsService.cs
+++ b/src/NewEggAccess/Services/Creds/NewEggCredsService.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using NewEggAccess.Configuration;
+using NewEggAccess.Exceptions;
+using NewEggAccess.Models.Commands;
+using NewEggAccess.Models.Orders;
+using NewEggAccess.Shared;
+
+namespace NewEggAccess.Services.Creds
+{
+	public class NewEggCredsService : BaseService, INewEggCredsService
+	{
+		public NewEggCredsService( NewEggConfig config, NewEggCredentials credentials ) : base( credentials, config )
+		{
+		}
+
+		public async Task<bool> AreNewEggCredentialsValid( CancellationToken token, Mark mark = null )
+		{
+			if ( mark == null )
+			{
+				mark = Mark.CreateNew();
+			}
+
+			int pageIndex = 1;
+			DateTime startDateUtc = DateTime.UtcNow;
+			DateTime endDateUtc = startDateUtc.AddMinutes( 1 );
+
+			var request = new GetOrderInfoRequest(
+					new GetOrderInfoRequestBody(
+						pageIndex,
+						base.Config.OrdersPageSize,
+						new GetOrderInfoRequestCriteria()
+						{
+							Type = 0,
+							Status = ( int )NewEggOrderStatusEnum.Unshipped,
+							OrderDateFrom = Misc.ConvertFromUtcToPstStr( startDateUtc ),
+							OrderDateTo = Misc.ConvertFromUtcToPstStr( endDateUtc )							
+						}));
+
+			var ordersPageServerResponse = await base.PutAsync( new GetModifiedOrdersCommand( base.Config, base.Credentials, request.ToJson() ), token, mark, ( code, response ) => false ).ConfigureAwait( false );
+
+			if ( ordersPageServerResponse.Error == null )
+			{
+				return true;
+			}
+			else
+			{
+				throw new NewEggException( ordersPageServerResponse.Error.Message );
+			}
+		}		
+	}
+}

--- a/src/NewEggAccess/Shared/Misc.cs
+++ b/src/NewEggAccess/Shared/Misc.cs
@@ -17,7 +17,9 @@ namespace NewEggAccess.Shared
 					return "{}";
 				else
 				{
-					var serialized = JsonConvert.SerializeObject( source, new IsoDateTimeConverter() );
+					var settings = new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore };
+					settings.Converters.Add( new IsoDateTimeConverter() );
+					var serialized = JsonConvert.SerializeObject( source, settings );
 					return serialized;
 				}
 			}

--- a/src/NewEggTests/BusinessAccount/BaseTest.cs
+++ b/src/NewEggTests/BusinessAccount/BaseTest.cs
@@ -1,0 +1,46 @@
+﻿using CsvHelper;
+using CsvHelper.Configuration;
+using NewEggAccess.Configuration;
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+
+namespace NewEggTests.BusinessAccount
+{
+	public abstract class BaseTest
+	{
+		protected NewEggConfig Config { get; private set; }
+		protected NewEggCredentials Credentials { get; private set; }
+
+		protected const string TestSku1 = "testSku1";
+		protected const string TestSku2 = "testSku2";		
+
+		public BaseTest()
+		{			
+			var testCredentials = this.LoadTestSettings< TestCredentials >( @"\..\..\credentials_business.csv" );
+			this.Credentials = new NewEggCredentials( testCredentials.SellerId, testCredentials.ApiKey, testCredentials.SecretKey );
+			this.Config = new NewEggConfig( (NewEggPlatform)Enum.Parse( typeof( NewEggPlatform ), testCredentials.Platform ) );
+		}
+
+		protected T LoadTestSettings< T >( string filePath )
+		{
+			string basePath = new Uri( Path.GetDirectoryName( Assembly.GetExecutingAssembly().CodeBase ) ).LocalPath;
+
+			using( var streamReader = new StreamReader( basePath + filePath ) )
+			{
+				var csvConfig = new Configuration()
+				{
+					Delimiter = ","
+				};
+
+				using( var csvReader = new CsvReader( streamReader, csvConfig ) )
+				{
+					var credentials = csvReader.GetRecords< T >();
+
+					return credentials.FirstOrDefault();
+				}
+			}
+		}
+	}
+}

--- a/src/NewEggTests/BusinessAccount/CredsTests.cs
+++ b/src/NewEggTests/BusinessAccount/CredsTests.cs
@@ -1,0 +1,28 @@
+﻿using FluentAssertions;
+using NewEggAccess.BusinessAccount.Services.Creds;
+using NUnit.Framework;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NewEggTests.BusinessAccount
+{
+	[ TestFixture ]
+	public class CredsTests : BaseTest
+	{
+		private NewEggCredsService _credsService;
+
+		[ SetUp ]
+		public void Init()
+		{
+			this._credsService = new NewEggCredsService( base.Config, base.Credentials );
+		}
+
+		[ Test ]
+		public async Task AreNewEggCredentialsValid()
+		{
+			var result = await this._credsService.AreNewEggCredentialsValid( CancellationToken.None );
+
+			result.Should().BeTrue();
+		}		
+	}
+}

--- a/src/NewEggTests/BusinessAccount/FeedsTests.cs
+++ b/src/NewEggTests/BusinessAccount/FeedsTests.cs
@@ -39,12 +39,14 @@ namespace NewEggTests.BusinessAccount
 		[ Test ]
 		public async Task UpdateItemQuantitiesThereSomeItemsAreNotExist()
 		{
+			var testSkuNotExist = "NotExistedSku";
 			var rand = new Random();
 			var inventory = new List< InventoryUpdateFeedItem> 
 			{
 				new InventoryUpdateFeedItem( TestSku1, null, rand.Next( 1, 100 ) ),
 				new InventoryUpdateFeedItem( TestSku2, null, rand.Next( 1, 100 ) ),
-				new InventoryUpdateFeedItem( new Guid().ToString(), null, rand.Next( 1, 100 ) )
+				new InventoryUpdateFeedItem( testSkuNotExist, null, 1 ),
+				new InventoryUpdateFeedItem( testSkuNotExist, null, 1 )
 			};
 
 			var feedId = await this._feedsService.UpdateItemsInventoryInBulkAsync( inventory, CancellationToken.None );
@@ -55,7 +57,7 @@ namespace NewEggTests.BusinessAccount
 		[ Test ]
 		public async Task GetFeedStatusAsync()
 		{
-			var feedId = "239JUBERAM1Q3";
+			var feedId = "26LY4588NXU3V";
 			var feedStatus = await this._feedsService.GetFeedStatusAsync( feedId, CancellationToken.None );
 
 			feedStatus.Should().NotBeNull();

--- a/src/NewEggTests/BusinessAccount/FeedsTests.cs
+++ b/src/NewEggTests/BusinessAccount/FeedsTests.cs
@@ -1,0 +1,64 @@
+﻿using FluentAssertions;
+using NewEggAccess.Models.Feeds;
+using NewEggAccess.Services.Feeds;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using NewEggFeedsService = NewEggAccess.BusinessAccount.Services.Feeds.NewEggFeedsService;
+
+namespace NewEggTests.BusinessAccount
+{
+	[ TestFixture ]
+	public class FeedsTests : BaseTest
+	{
+		private INewEggFeedsService _feedsService;		
+
+		[ SetUp ]
+		public void Init()
+		{
+			this._feedsService = new NewEggFeedsService( base.Config, base.Credentials );
+		}
+
+		[ Test ]
+		public async Task UpdateItemQuantitiesInBulkAsync()
+		{
+			var rand = new Random();
+			var inventory = new List< InventoryUpdateFeedItem> 
+			{
+				new InventoryUpdateFeedItem( TestSku1, null, rand.Next( 1, 100 ) ),
+				new InventoryUpdateFeedItem( TestSku2, null, rand.Next( 1, 100 ) )
+			};
+
+			var feedId = await this._feedsService.UpdateItemsInventoryInBulkAsync( inventory, CancellationToken.None );
+
+			feedId.Should().NotBeNullOrWhiteSpace();
+		}
+
+		[ Test ]
+		public async Task UpdateItemQuantitiesThereSomeItemsAreNotExist()
+		{
+			var rand = new Random();
+			var inventory = new List< InventoryUpdateFeedItem> 
+			{
+				new InventoryUpdateFeedItem( TestSku1, null, rand.Next( 1, 100 ) ),
+				new InventoryUpdateFeedItem( TestSku2, null, rand.Next( 1, 100 ) ),
+				new InventoryUpdateFeedItem( new Guid().ToString(), null, rand.Next( 1, 100 ) )
+			};
+
+			var feedId = await this._feedsService.UpdateItemsInventoryInBulkAsync( inventory, CancellationToken.None );
+
+			feedId.Should().NotBeNullOrWhiteSpace();
+		}
+
+		[ Test ]
+		public async Task GetFeedStatusAsync()
+		{
+			var feedId = "239JUBERAM1Q3";
+			var feedStatus = await this._feedsService.GetFeedStatusAsync( feedId, CancellationToken.None );
+
+			feedStatus.Should().NotBeNull();
+		}
+	}
+}

--- a/src/NewEggTests/BusinessAccount/ItemTests.cs
+++ b/src/NewEggTests/BusinessAccount/ItemTests.cs
@@ -1,0 +1,100 @@
+﻿using FluentAssertions;
+using NewEggAccess.BusinessAccount.Models.Items;
+using NewEggAccess.BusinessAccount.Services.Items;
+using NewEggAccess.Services.Items;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NewEggItemsService = NewEggAccess.BusinessAccount.Services.Items.NewEggItemsService;
+
+namespace NewEggTests.BusinessAccount
+{
+	[ TestFixture ]
+	public class ItemTests : BaseTest
+	{
+		private INewEggItemsService _itemsService;
+
+		[ SetUp ]
+		public void Init()
+		{
+			this._itemsService = new NewEggItemsService( base.Config, base.Credentials );
+		}
+
+		[ Test ]
+		public async Task GetItemInventoryThatExists()
+		{
+			var itemInventory = await this._itemsService.GetSkuInventory( TestSku1, null, CancellationToken.None );
+			
+			itemInventory.SellerPartNumber.ToLower().Should().Be( TestSku1.ToLower() );
+			itemInventory.InventoryAllocation.First().AvailableQuantity.Should().BeGreaterThan( 0 );
+		}
+
+		[ Test ]
+		public async Task GetItemInventoryThatDoesntExist()
+		{
+			var sku = Guid.NewGuid().ToString();
+			var itemInventory = await this._itemsService.GetSkuInventory( sku, null, CancellationToken.None );
+			itemInventory.Should().BeNull();
+		}
+
+		[ Test ]
+		public void GetItemInventory_WhenSkuTooLong_ShouldThrow()
+		{
+			var longSku = new string( 'a', ItemInventoryRequest.MaxSellerPartNumberLength + 1 );
+				
+			Assert.ThrowsAsync< ArgumentException >( async () => 
+			{
+				await this._itemsService.GetSkuInventory( longSku, null, CancellationToken.None );
+			} );
+		}
+
+		[ Test ]
+		public async Task UpdateItemInventoryThatExists()
+		{
+			var quantity = new Random().Next( 1, 100 );
+			var itemInventory = await this._itemsService.UpdateSkuQuantityAsync( TestSku1, null, quantity, CancellationToken.None );
+
+			itemInventory.Should().NotBeNull();
+			itemInventory.SellerPartNumber.ToLower().Should().Be( TestSku1.ToLower() );
+			itemInventory.InventoryList.First().AvailableQuantity.Should().Be( quantity );
+		}
+
+		[ Test ]
+		public async Task UpdateItemInventoryThatDoesntExist()
+		{
+			var quantity = new Random().Next( 1, 100 );
+			var sku = Guid.NewGuid().ToString();
+			var itemInventory = await this._itemsService.UpdateSkuQuantityAsync( sku, null, quantity, CancellationToken.None );
+
+			itemInventory.Should().BeNull();
+		}
+
+		[ Test ]
+		public async Task UpdateItemsInventory()
+		{
+			var rand = new Random();
+			var inventory = new Dictionary< string, int >
+			{
+				{ TestSku1, rand.Next( 1, 100 ) },
+				{ TestSku2, rand.Next( 1, 100 ) }
+			};
+
+			await this._itemsService.UpdateSkusQuantitiesAsync( inventory, null, CancellationToken.None );
+		}
+
+		[Test ]
+		public void UpdateItemInventory_WhenSkuTooLong_ShouldThrow()
+		{
+			var quantity = new Random().Next( 1, 100 );
+			var longSku = new string( 'a', ItemInventoryRequest.MaxSellerPartNumberLength + 1 ); ;
+
+			Assert.ThrowsAsync< ArgumentException >( async () =>
+			{
+				await this._itemsService.UpdateSkuQuantityAsync( longSku, null, quantity, CancellationToken.None );
+			} );
+		}
+	}
+}

--- a/src/NewEggTests/BusinessAccount/ItemTests.cs
+++ b/src/NewEggTests/BusinessAccount/ItemTests.cs
@@ -1,6 +1,6 @@
 ﻿using FluentAssertions;
 using NewEggAccess.BusinessAccount.Models.Items;
-using NewEggAccess.BusinessAccount.Services.Items;
+using NewEggAccess.Exceptions;
 using NewEggAccess.Services.Items;
 using NUnit.Framework;
 using System;
@@ -83,6 +83,21 @@ namespace NewEggTests.BusinessAccount
 			};
 
 			await this._itemsService.UpdateSkusQuantitiesAsync( inventory, null, CancellationToken.None );
+		}
+
+		[Test]
+		public async Task UpdateItemsInventory_WhenSkuAndQuantityDuplicatedAndDoesntExist_ShouldNotThrowCT055Error()
+		{			
+			var inventory = new Dictionary< string, int >
+			{
+				{ "NotExistedSku", 1 }
+			};
+			
+			for( var i = 0; i < 6; i++ )
+			{
+				await this._itemsService.UpdateSkusQuantitiesAsync( inventory, null, CancellationToken.None );
+				await Task.Delay( 1000 );
+			}			
 		}
 
 		[Test ]

--- a/src/NewEggTests/BusinessAccount/ItemTests.cs
+++ b/src/NewEggTests/BusinessAccount/ItemTests.cs
@@ -86,18 +86,20 @@ namespace NewEggTests.BusinessAccount
 		}
 
 		[Test]
-		public async Task UpdateItemsInventory_WhenSkuAndQuantityDuplicatedAndDoesntExist_ShouldNotThrowCT055Error()
+		public void UpdateItemsInventory_WhenSkuAndQuantityDuplicatedAndDoesntExist_ShouldNotThrowCT055Error()
 		{			
 			var inventory = new Dictionary< string, int >
 			{
 				{ "NotExistedSku", 1 }
 			};
 			
-			for( var i = 0; i < 6; i++ )
-			{
-				await this._itemsService.UpdateSkusQuantitiesAsync( inventory, null, CancellationToken.None );
-				await Task.Delay( 1000 );
-			}			
+			Assert.DoesNotThrowAsync( async() => {
+				for (var i = 0; i < 6; i++)
+				{
+					await this._itemsService.UpdateSkusQuantitiesAsync( inventory, null, CancellationToken.None );
+					await Task.Delay( 1000 );
+				}
+			} );
 		}
 
 		[Test ]

--- a/src/NewEggTests/BusinessAccount/OrderTests.cs
+++ b/src/NewEggTests/BusinessAccount/OrderTests.cs
@@ -1,0 +1,75 @@
+﻿using FluentAssertions;
+using NewEggAccess.BusinessAccount.Services.Orders;
+using NewEggAccess.Services;
+using NSubstitute;
+using NUnit.Framework;
+using System;
+using System.IO;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NewEggTests.BusinessAccount
+{
+	[ TestFixture ]
+	public class OrderTests : BaseTest
+	{
+		private NewEggOrdersService _orderService;
+		private DateTime _startDate = DateTime.Now.AddMonths( -2 );
+		private DateTime _endDate = DateTime.Now;
+
+		[ SetUp ]
+		public void Init()
+		{
+			this._orderService = new NewEggOrdersService( base.Config, base.Credentials );
+		}
+
+		[ Test ]
+		public async Task GetModifiedOrders()
+		{
+			var orders = await this._orderService.GetModifiedOrdersAsync( _startDate, _endDate, null, CancellationToken.None );
+
+			orders.Should().NotBeEmpty();
+		}
+
+		[ Test ]
+		public async Task GetModifiedOrdersBySmallPage()
+		{
+			base.Config.OrdersPageSize = 1;
+			var orders = await this._orderService.GetModifiedOrdersAsync( _startDate, _endDate, null, CancellationToken.None );
+
+			orders.Should().NotBeEmpty();
+		}
+
+		[ Test ]
+		public async Task GetModifiedOrdersMockResponse()
+		{
+			this._orderService.HttpClient = this.GetMock( "GetOrderInformation.json" );
+
+			var orders = await this._orderService.GetModifiedOrdersAsync( _startDate, _endDate, null, CancellationToken.None );
+
+			orders.Should().NotBeEmpty();
+		}
+
+		private IHttpClient GetMock( string fileWithResponsePath )
+		{
+			var httpClientMock = Substitute.For< IHttpClient >();
+			var httpResponseMock = Substitute.For< IHttpResponseMessage >();
+			httpResponseMock.ReadContentAsStringAsync().Returns( this.GetFileResponseContent( fileWithResponsePath ) );
+			httpResponseMock.IsSuccessStatusCode.Returns( true );
+			httpResponseMock.StatusCode.Returns( System.Net.HttpStatusCode.OK );
+			
+			httpClientMock.PutAsync( null, null, CancellationToken.None ).ReturnsForAnyArgs( httpResponseMock );
+
+			return httpClientMock;
+		}
+
+		private string GetFileResponseContent( string fileName )
+		{
+			string basePath = new Uri( Path.GetDirectoryName( Assembly.GetExecutingAssembly().CodeBase ) ).LocalPath;
+			var path = basePath + @"\..\..\Responses\" + fileName;
+
+			return File.ReadAllText( path );
+		}
+	}
+}

--- a/src/NewEggTests/BusinessAccount/OrderTests.cs
+++ b/src/NewEggTests/BusinessAccount/OrderTests.cs
@@ -15,7 +15,7 @@ namespace NewEggTests.BusinessAccount
 	public class OrderTests : BaseTest
 	{
 		private NewEggOrdersService _orderService;
-		private DateTime _startDate = DateTime.Now.AddMonths( -2 );
+		private DateTime _startDate = DateTime.Now.AddMonths( -4 );
 		private DateTime _endDate = DateTime.Now;
 
 		[ SetUp ]

--- a/src/NewEggTests/CredsTests.cs
+++ b/src/NewEggTests/CredsTests.cs
@@ -1,0 +1,28 @@
+﻿using FluentAssertions;
+using NewEggAccess.Services.Creds;
+using NUnit.Framework;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NewEggTests
+{
+	[ TestFixture ]
+	public class CredsTests : BaseTest
+	{
+		private NewEggCredsService _credsService;
+
+		[ SetUp ]
+		public void Init()
+		{
+			this._credsService = new NewEggCredsService( base.Config, base.Credentials );
+		}
+
+		[ Test ]
+		public async Task AreNewEggCredentialsValid()
+		{
+			var result = await this._credsService.AreNewEggCredentialsValid( CancellationToken.None );
+
+			result.Should().BeTrue();
+		}		
+	}
+}

--- a/src/NewEggTests/FeedsTests.cs
+++ b/src/NewEggTests/FeedsTests.cs
@@ -54,7 +54,7 @@ namespace NewEggTests
 		[ Test ]
 		public async Task GetFeedStatusAsync()
 		{
-			var feedId = "ZJPV7DEMPS5D";
+			var feedId = "23FZKD2FCBZ06";
 			var feedStatus = await this._feedsService.GetFeedStatusAsync( feedId, CancellationToken.None );
 
 			feedStatus.Should().NotBeNull();

--- a/src/NewEggTests/FeedsTests.cs
+++ b/src/NewEggTests/FeedsTests.cs
@@ -54,7 +54,7 @@ namespace NewEggTests
 		[ Test ]
 		public async Task GetFeedStatusAsync()
 		{
-			var feedId = "24ZVF18VYNJK1";
+			var feedId = "ZJPV7DEMPS5D";
 			var feedStatus = await this._feedsService.GetFeedStatusAsync( feedId, CancellationToken.None );
 
 			feedStatus.Should().NotBeNull();

--- a/src/NewEggTests/ItemTests.cs
+++ b/src/NewEggTests/ItemTests.cs
@@ -25,7 +25,7 @@ namespace NewEggTests
 		public async Task GetItemInventoryThatExists()
 		{
 			var itemInventory = await this._itemsService.GetSkuInventory( TestSku1, WarehouseLocationCountryCode, CancellationToken.None );
-			
+
 			itemInventory.SellerPartNumber.ToLower().Should().Be( TestSku1.ToLower() );
 			itemInventory.InventoryAllocation.First().AvailableQuantity.Should().BeGreaterThan( 0 );
 		}
@@ -34,7 +34,7 @@ namespace NewEggTests
 		public async Task GetItemInventoryThatDoesntExist()
 		{
 			var sku = Guid.NewGuid().ToString();
-			var itemInventory = await this._itemsService.GetSkuInventory( sku, WarehouseLocationCountryCode, CancellationToken.None );
+			var itemInventory = await this._itemsService.GetSkuInventory(sku, WarehouseLocationCountryCode, CancellationToken.None);
 			itemInventory.Should().BeNull();
 		}
 
@@ -42,8 +42,8 @@ namespace NewEggTests
 		public void GetItemInventory_WhenSkuTooLong_ShouldThrow()
 		{
 			var longSku = new string( 'a', ItemInventoryRequest.MaxSellerPartNumberLength + 1 );
-				
-			Assert.ThrowsAsync< ArgumentException >( async () => 
+
+			Assert.ThrowsAsync< ArgumentException >( async () =>
 			{
 				await this._itemsService.GetSkuInventory( longSku, WarehouseLocationCountryCode, CancellationToken.None );
 			} );
@@ -68,6 +68,21 @@ namespace NewEggTests
 			var itemInventory = await this._itemsService.UpdateSkuQuantityAsync( sku, WarehouseLocationCountryCode, quantity, CancellationToken.None );
 
 			itemInventory.Should().BeNull();
+		}
+
+		[Test]
+		public async Task UpdateItemsInventory_WhenSkuAndQuantityDuplicatedAndDoesntExist_ShouldNotThrowCT055Error()
+		{
+			var inventory = new Dictionary< string, int >
+			{
+				{ "NotExistedSku", 1 }
+			};
+
+			for( var i = 0; i < 6; i++ )
+			{
+				await this._itemsService.UpdateSkusQuantitiesAsync( inventory, WarehouseLocationCountryCode, CancellationToken.None );
+				await Task.Delay( 1000 );
+			}
 		}
 
 		[ Test ]

--- a/src/NewEggTests/NewEggTests.csproj
+++ b/src/NewEggTests/NewEggTests.csproj
@@ -79,10 +79,16 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BaseTest.cs" />
+    <Compile Include="BusinessAccount\BaseTest.cs" />
+    <Compile Include="BusinessAccount\CredsTests.cs" />
+    <Compile Include="BusinessAccount\FeedsTests.cs" />
+    <Compile Include="BusinessAccount\ItemTests.cs" />
+    <Compile Include="BusinessAccount\OrderTests.cs" />
     <Compile Include="FeedsTests.cs" />
     <Compile Include="ItemTests.cs" />
     <Compile Include="DateTimeConversionTests.cs" />
     <Compile Include="OrderMapperTests.cs" />
+    <Compile Include="CredsTests.cs" />
     <Compile Include="OrderTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RateLimitTests.cs" />
@@ -100,6 +106,7 @@
   <ItemGroup>
     <None Include="Responses\GetOrderInformation.json" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/NewEggTests/OrderTests.cs
+++ b/src/NewEggTests/OrderTests.cs
@@ -15,6 +15,8 @@ namespace NewEggTests
 	public class OrderTests : BaseTest
 	{
 		private NewEggOrdersService _orderService;
+		private DateTime _startDate = DateTime.Now.AddMonths( -2 );
+		private DateTime _endDate = DateTime.Now;
 
 		[ SetUp ]
 		public void Init()
@@ -25,7 +27,7 @@ namespace NewEggTests
 		[ Test ]
 		public async Task GetModifiedOrders()
 		{
-			var orders = await this._orderService.GetModifiedOrdersAsync( DateTime.Now.AddMonths( -1 ), DateTime.Now, WarehouseLocationCountryCode, CancellationToken.None );
+			var orders = await this._orderService.GetModifiedOrdersAsync( _startDate, _endDate, WarehouseLocationCountryCode, CancellationToken.None );
 
 			orders.Should().NotBeEmpty();
 		}
@@ -34,7 +36,7 @@ namespace NewEggTests
 		public async Task GetModifiedOrdersBySmallPage()
 		{
 			base.Config.OrdersPageSize = 1;
-			var orders = await this._orderService.GetModifiedOrdersAsync( DateTime.Now.AddMonths( -1 ), DateTime.Now, WarehouseLocationCountryCode, CancellationToken.None );
+			var orders = await this._orderService.GetModifiedOrdersAsync( _startDate, _endDate, WarehouseLocationCountryCode, CancellationToken.None );
 
 			orders.Should().NotBeEmpty();
 		}
@@ -44,7 +46,7 @@ namespace NewEggTests
 		{
 			this._orderService.HttpClient = this.GetMock( "GetOrderInformation.json" );
 
-			var orders = await this._orderService.GetModifiedOrdersAsync( DateTime.Now.AddDays( -1 ), DateTime.Now, WarehouseLocationCountryCode, CancellationToken.None );
+			var orders = await this._orderService.GetModifiedOrdersAsync( _startDate, _endDate, WarehouseLocationCountryCode, CancellationToken.None );
 
 			orders.Should().NotBeEmpty();
 		}
@@ -53,7 +55,7 @@ namespace NewEggTests
 		{
 			var httpClientMock = Substitute.For< IHttpClient >();
 			var httpResponseMock = Substitute.For< IHttpResponseMessage >();
-			httpResponseMock.ReadContentAsStringAsync().Returns( this.GetFileResponseContent( "GetOrderInformation.json" ) );
+			httpResponseMock.ReadContentAsStringAsync().Returns( this.GetFileResponseContent( fileWithResponsePath ) );
 			httpResponseMock.IsSuccessStatusCode.Returns( true );
 			httpResponseMock.StatusCode.Returns( System.Net.HttpStatusCode.OK );
 			


### PR DESCRIPTION
**Problem:**
Inventory Sync randomly fails with CT055 error.

I have reproduced the problem with the unit test (UpdateItemsInventory_WhenSkuAndQuantityDuplicatedAndDoesntExist_ShouldNotThrowCT055Error) and for the BusinessAccount only. As stated in the response error description https://developer.newegg.com/newegg_marketplace_api/item_management/update_inventory_and_price/ this happens if we duplicate update requests for a product that does not exist in NewEgg. 
![image](https://user-images.githubusercontent.com/80940351/124929586-4c0a4100-e009-11eb-9ac4-b69e9cc81652.png)

**Solution**

I just added CT055 to the list of allowed errors, that is, the error will be logged in v1, but the integration will not break. Also I added some fixes across unit tests so that they are successfully passed at moment.

PS. I've merged the 1846 branch to the current (we have opened PR on it also and this ticket blocked them)